### PR TITLE
Fix disappearing planets in network games (they turned into BHs)

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,9 @@ at http://github.com/ryanakca/slingshot
 
 See http://github.com/ryanakca/slingshot/commits/master for a detailed listing.
 
+v0.9r1:
+ - Fix bug in network games (disappearing planets)
+
 v0.9:
  - Fix deprecation Python warnings and errors
  - Introduce networking support
@@ -63,6 +66,7 @@ Copyright:
       Copyright (C) 2007 Bart Mak
       Copyright (C) 2009 Marcus Dreier <m-rei@gmx.net>
       Copyright (C) 2010 Ryan Kavanagh <ryanakca@kubuntu.org>
+      Copyright (C) 2019 H. A. L. <hans.liegener@fau.de> (contributions to v0.9r1)
     slingshot/data/FreeSansBold.ttf:
       Copyright (C) 2002, 2003, 2005, 2008 Free Software Foundation
 

--- a/src/bin/slingshot
+++ b/src/bin/slingshot
@@ -1034,7 +1034,8 @@ class Game:
 
         if ret is not False:
             packet = (self.bounce, self.fixed_power, self.invisible, self.random, self.max_planets, self.timeout, self.max_rounds, self.max_blackholes)
-            if not self.net.send(packet):
+            if self.net.send(packet) == False:
+                print "ERROR in host_game_init when sending"
                 self.menu = self.net_error_menu
                 self.net.close()
                 return
@@ -1042,6 +1043,7 @@ class Game:
             self.save_settings()
             self.game_init(net_host=True)
         else:
+            print "ERROR in host_game_init in connecting"
             self.menu = self.net_error_menu
             self.net.close()
 
@@ -1051,9 +1053,9 @@ class Game:
 
         self.net = Network(3999)
 
-        if self.net.cnct(hostname) is not False:
+        if self.net.cnct(hostname) != False:
             packet = self.net.recv()
-            if not packet:
+            if packet == False:
                 self.menu = self.net_error_menu
                 self.net.close()
                 return
@@ -1069,6 +1071,7 @@ class Game:
 
             self.menu = None
             self.save_settings()
+            print "client_game_init succeded"
             self.game_init(net_client=True)
         else:
             self.menu = self.net_error_menu
@@ -1082,15 +1085,17 @@ class Game:
         y_coordlist = (self.players[1].get_rect_y_coord(), self.players[2].get_rect_y_coord())
 
         packet = (planetlist, y_coordlist)
-        if not self.net.send(packet):
+        if self.net.send(packet) == False:
+            print "ERROR in host_round_init "
             self.menu = self.net_error_menu
             self.net.close()
 
     def client_round_init(self):
         ret = self.net.recv()
-        if not ret:
+        if ret == False:
             self.menu = self.net_error_menu
             self.net.close()
+            return None
         return ret
 
     def use_fullscreen(self):
@@ -1108,7 +1113,7 @@ def main():
     path = os.path.expanduser("~") + "/.slingshot"
     if not os.path.exists(path):
         os.mkdir(path)
-    path += "/logfile.txt"
+    path += "/logfile" + str(randint(1,10000)) + ".txt"
     sys.stderr = open(path, "w")
     sys.stdout = sys.stderr
     game = Game()

--- a/src/bin/slingshot
+++ b/src/bin/slingshot
@@ -1034,7 +1034,7 @@ class Game:
 
         if ret is not False:
             packet = (self.bounce, self.fixed_power, self.invisible, self.random, self.max_planets, self.timeout, self.max_rounds, self.max_blackholes)
-            if self.net.send(packet) == False:
+            if self.net.send(packet) is False:
                 print "ERROR in host_game_init when sending"
                 self.menu = self.net_error_menu
                 self.net.close()
@@ -1053,7 +1053,7 @@ class Game:
 
         self.net = Network(3999)
 
-        if self.net.cnct(hostname) != False:
+        if self.net.cnct(hostname) is not False:
             packet = self.net.recv()
             if packet == False:
                 self.menu = self.net_error_menu
@@ -1085,7 +1085,7 @@ class Game:
         y_coordlist = (self.players[1].get_rect_y_coord(), self.players[2].get_rect_y_coord())
 
         packet = (planetlist, y_coordlist)
-        if self.net.send(packet) == False:
+        if self.net.send(packet) is False:
             print "ERROR in host_round_init "
             self.menu = self.net_error_menu
             self.net.close()
@@ -1113,6 +1113,8 @@ def main():
     path = os.path.expanduser("~") + "/.slingshot"
     if not os.path.exists(path):
         os.mkdir(path)
+    # randomize name of logfile for debugging, since multiple instances might be
+    # running for the same user
     path += "/logfile" + str(randint(1,10000)) + ".txt"
     sys.stderr = open(path, "w")
     sys.stdout = sys.stderr

--- a/src/bin/slingshot
+++ b/src/bin/slingshot
@@ -371,8 +371,9 @@ class Game:
                     result.add(Planet(result, self.background))
         else:
             for p in planetlist:
-                if p[0] > Settings.MAX_PLANETS:
-                    # Numbers above Settings.MAX_PLANETS are
+                if p[0] > Settings.NUM_PLANET_SPRITES:
+                    # Numbers above
+                    # Settings.NUM_PLANET_SPRITES are
                     # allocated to blackholes.
                     result.add(Blackhole(None, self.background, p[0], p[1], p[2], p[3]))
                 else:

--- a/src/bin/slingshot
+++ b/src/bin/slingshot
@@ -1093,11 +1093,11 @@ class Game:
             self.net.close()
         return ret
 
-        def use_fullscreen(self):
-                pygame.display.set_mode((0, 0), pygame.FULLSCREEN | pygame.NOFRAME)
+    def use_fullscreen(self):
+            pygame.display.set_mode((0, 0), pygame.FULLSCREEN | pygame.NOFRAME)
 
-        def use_window(self):
-                pygame.display.set_mode((800, 600))
+    def use_window(self):
+            pygame.display.set_mode((800, 600))
 
 
 def main():

--- a/src/slingshot/planet.py
+++ b/src/slingshot/planet.py
@@ -60,7 +60,7 @@ class Planet(pygame.sprite.Sprite):
 			unique = False
 			while not unique:
 				unique = True
-				self.n = randint(1, 8)
+				self.n = randint(1, Settings.NUM_PLANET_SPRITES)
 				for p in planets:
 					if self.n == p.get_n():
 						unique = False
@@ -143,7 +143,8 @@ class Blackhole(Planet):
 			unique = False
 			while not unique:
 				unique = True
-				self.n = randint(Settings.MAX_PLANETS + 1, Settings.MAX_PLANETS + Settings.MAX_BLACKHOLES + 1)
+				self.n = randint(Settings.NUM_PLANET_SPRITES +
+                                        1, Settings.NUM_PLANET_SPRITES + Settings.MAX_BLACKHOLES + 1)
 				for p in planets:
 					if self.n == p.get_n():
 						unique = False

--- a/src/slingshot/settings.py
+++ b/src/slingshot/settings.py
@@ -26,7 +26,7 @@ import os.path
 
 class Settings:
 
-        VERSION = '0.9'
+        VERSION = '0.9r1'
 
 	g = 120 # gravity
 	MAXPOWER = 350
@@ -52,6 +52,10 @@ class Settings:
 	MAX_FLIGHT = 750
 
 	MAX_PLANETS = 4
+        # MAX_PLANTES_SPRITES is the number of planet sprites, hence the maximal
+        # number for any Planet.n and we can identify BHs by haveing an n >
+        # NUM_PLANET_SPRITES
+        NUM_PLANET_SPRITES = 8
         MAX_BLACKHOLES = 0
 
 	HITSCORE = 1500


### PR DESCRIPTION
This fixes a bug in network games: Some plantes would (visually randomly) disappear in the client game. Inspection showed, that the client instance would create Black Holes for any planet of the host instance which has a sprite number (`Planet.n`) larger than `MAX_PLANETS`, however, this is not sensible.  By replacing this with the number of sprites (8 in the current implementation), the bug is fixed.  Since the numebr of sprites might change, a corresponding constant was introduced into as `Settings.NUM_PLANET_SPRITES`.